### PR TITLE
Always use a float type

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use influxdb::InfluxDbWriteable;
-use influxdb::{Client, Query, ReadQuery, Timestamp};
-use rumqttc::{AsyncClient, Event, Packet, Publish, QoS};
+use influxdb::Client;
+use rumqttc::{AsyncClient, Event, Packet, QoS};
 use serde::Deserialize;
 use std::fs;
 use std::str;

--- a/src/types.rs
+++ b/src/types.rs
@@ -40,7 +40,7 @@ pub struct WritableEvent {
     id_hex: String,
     #[influxdb(tag)]
     sid: String,
-    rssi: i32,
+    rssi: f32,
     temp_c: Option<f32>,
     rh: Option<f32>,
     vbat: f32,
@@ -71,7 +71,7 @@ impl From<Event> for WritableEvent {
                 name: e.meta.name,
                 id_hex: e.meta.id_hex,
                 sid: e.meta.sid,
-                rssi,
+                rssi: rssi as f32,
                 temp_c,
                 rh,
                 vbat,


### PR DESCRIPTION
Integers written after an implied float will fail at influx due to type errors. Just use a float for this