### PR TITLE
feat: (re)name sensors

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,6 +16,13 @@ jobs:
     with:
       automerge: true
 
+  check-for-cc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check-for-cc
+        id: check-for-cc
+        uses: agenthunt/conventional-commit-checker-action@v2.0.0
+
   docker_build:
     uses: "philipcristiano/workflows/.github/workflows/docker-build.yml@main"
     with:

--- a/.github/workflows/push_main.yml
+++ b/.github/workflows/push_main.yml
@@ -4,16 +4,19 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "*"
+
+permissions:
+  pull-requests: write
+  contents: write
 
 jobs:
 
   docker_push:
     name: "Push docker image"
     uses: "philipcristiano/workflows/.github/workflows/docker-build-push.yml@main"
+    needs: [flake, rust]
     with:
-      repository: philipcristiano/hvac-iot-mqtt-influx
+      repository: ${{ github.repository }}
       timeout: 25
 
     secrets:
@@ -22,6 +25,13 @@ jobs:
 
   rust:
     uses: "philipcristiano/workflows/.github/workflows/rust.yml@main"
+
+  rust_release:
+    uses: "philipcristiano/workflows/.github/workflows/rust_release.yml@main"
+    needs: [flake, rust]
+    secrets:
+      WF_GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   flake:
     uses: "philipcristiano/workflows/.github/workflows/nix.yml@main"

--- a/hvac_iot.toml.example
+++ b/hvac_iot.toml.example
@@ -11,4 +11,8 @@ host = "https://influxdb.example.com"
 bucket = "environment"
 token = "influxdb-token"
 
-
+# Override the sensor name
+[[sensor]]
+id_hex = "hex_value"
+[sensor.overwrite]
+name = "New sensor name"

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,16 +4,16 @@ use serde::Deserialize;
 use std::time::SystemTime;
 #[derive(Clone, Debug, Deserialize)]
 pub struct Event {
-    data: EventData,
-    meta: EventMeta,
-    time: Option<SystemTime>,
+    pub data: EventData,
+    pub meta: EventMeta,
+    pub time: Option<SystemTime>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct EventMeta {
-    name: String,
-    id_hex: String,
-    sid: String,
+    pub name: String,
+    pub id_hex: String,
+    pub sid: String,
 }
 
 #[derive(Clone, Debug, Deserialize)]


### PR DESCRIPTION
Allow renaming sensors to move the configuration of id -> hex to this part of the stack. Flashing the hub IoT device for names is cumbersome by comparison

Also update the Rust pipeline for the project.