### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,112 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.4](https://github.com/philipcristiano/hvac-iot-mqtt-influx/releases/tag/v0.1.4) - 2024-01-21
+
+### Added
+- (re)name sensors
+
+### Fixed
+- fix
+
+### Other
+- Add crates-required package info
+- Update version
+- Update rust pipeline
+- *(deps)* bump the patch-dependencies group with 1 update
+- *(deps)* bump the patch-dependencies group with 4 updates
+- *(deps)* bump rust from 1.74-bookworm to 1.75-bookworm
+- *(deps)* bump the patch-dependencies group with 3 updates
+- *(deps)* bump the patch-dependencies group with 2 updates
+- *(deps)* bump the minor-dependencies group with 1 update
+- *(deps)* bump the patch-dependencies group with 1 update
+- *(deps)* bump the patch-dependencies group with 1 update
+- Group changes
+- *(deps)* bump the dependencies group with 2 updates
+- Update dependabot.yml
+- *(deps)* bump rust from 1.73-bookworm to 1.74-bookworm
+- *(deps)* bump tracing-subscriber from 0.3.17 to 0.3.18
+- *(deps)* bump clap from 4.4.7 to 4.4.8
+- *(deps)* bump serde from 1.0.190 to 1.0.192
+- *(deps)* bump tokio from 1.33.0 to 1.34.0
+- *(deps)* bump toml from 0.8.6 to 0.8.8
+- *(deps)* bump clap from 4.4.6 to 4.4.7
+- *(deps)* bump serde_json from 1.0.107 to 1.0.108
+- *(deps)* bump serde from 1.0.189 to 1.0.190
+- *(deps)* bump toml from 0.8.2 to 0.8.6
+- Automerge dependabot
+- *(deps)* bump tracing from 0.1.37 to 0.1.40
+- Remove oidc
+- *(deps)* bump openidconnect from 3.3.1 to 3.4.0
+- *(deps)* bump serde from 1.0.188 to 1.0.189
+- *(deps)* bump toml from 0.8.1 to 0.8.2
+- *(deps)* bump rumqttc from 0.22.0 to 0.23.0
+- *(deps)* bump tokio from 1.32.0 to 1.33.0
+- *(deps)* bump rust from 1.72-bookworm to 1.73-bookworm
+- *(deps)* bump clap from 4.4.4 to 4.4.6
+- *(deps)* bump toml from 0.8.0 to 0.8.1
+- *(deps)* bump clap from 4.4.3 to 4.4.4
+- *(deps)* bump chrono from 0.4.30 to 0.4.31
+- *(deps)* bump bytes from 1.4.0 to 1.5.0
+- *(deps)* bump clap from 4.4.2 to 4.4.3
+- *(deps)* bump toml from 0.7.8 to 0.8.0
+- *(deps)* bump serde_json from 1.0.106 to 1.0.107
+- *(deps)* bump toml from 0.7.6 to 0.7.8
+- *(deps)* bump influxdb from 0.7.0 to 0.7.1
+- *(deps)* bump openidconnect from 3.3.0 to 3.3.1
+- *(deps)* bump serde_json from 1.0.105 to 1.0.106
+- *(deps)* bump chrono from 0.4.28 to 0.4.30
+- Map types as floats explicitly
+- Always use a float type
+- *(deps)* bump clap from 4.4.0 to 4.4.2
+- *(deps)* bump url from 2.4.0 to 2.4.1
+- *(deps)* bump chrono from 0.4.26 to 0.4.28
+- Use same debian version
+- *(deps)* bump serde from 1.0.183 to 1.0.188
+- *(deps)* bump clap from 4.3.23 to 4.4.0
+- rust 1.72
+- Log levels via CLI
+- Simplify
+- Use tracing for logs
+- Include temp_c
+- Include tvoc
+- Fix naming mismatch.
+- *(deps)* bump clap from 4.3.22 to 4.3.23
+- Push with default repo
+- Start Rust port
+- remove elixir config
+- Use standard "message" key for messages
+- Use JSON logging format
+- more tracing
+- Start tracing
+- start emqtt
+- Downgrade
+- Start public_key
+- Fix boot
+- Tag release
+- Merge pull request [#9](https://github.com/philipcristiano/hvac-iot-mqtt-influx/pull/9) from philipcristiano/rebar
+- Start moving to rebar3
+- Remove protocol from host
+- Read a local config file
+- Handle connection errors
+- Handle connection errors
+- Fix dialyze error
+- erlftm
+- Always read body
+- Update hackney
+- Add sentry
+- Decode specific JSON messages
+- Fix type for headers
+- Don't use git version stuff as it breaks in the docker build action
+- erlfmt
+- Push to docker hub
+- Post message to influxdb
+- Use new GH branch default name
+- Subscribe to metrics topic
+- Init project
+- Initial commit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hvac_iot"
-version = "0.1.0"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "bytes",


### PR DESCRIPTION
## 🤖 New release
* `hvac_iot`: 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/philipcristiano/hvac-iot-mqtt-influx/releases/tag/v0.1.4) - 2024-01-21

### Added
- (re)name sensors

### Fixed
- fix

### Other
- Add crates-required package info
- Update version
- Update rust pipeline
- *(deps)* bump the patch-dependencies group with 1 update
- *(deps)* bump the patch-dependencies group with 4 updates
- *(deps)* bump rust from 1.74-bookworm to 1.75-bookworm
- *(deps)* bump the patch-dependencies group with 3 updates
- *(deps)* bump the patch-dependencies group with 2 updates
- *(deps)* bump the minor-dependencies group with 1 update
- *(deps)* bump the patch-dependencies group with 1 update
- *(deps)* bump the patch-dependencies group with 1 update
- Group changes
- *(deps)* bump the dependencies group with 2 updates
- Update dependabot.yml
- *(deps)* bump rust from 1.73-bookworm to 1.74-bookworm
- *(deps)* bump tracing-subscriber from 0.3.17 to 0.3.18
- *(deps)* bump clap from 4.4.7 to 4.4.8
- *(deps)* bump serde from 1.0.190 to 1.0.192
- *(deps)* bump tokio from 1.33.0 to 1.34.0
- *(deps)* bump toml from 0.8.6 to 0.8.8
- *(deps)* bump clap from 4.4.6 to 4.4.7
- *(deps)* bump serde_json from 1.0.107 to 1.0.108
- *(deps)* bump serde from 1.0.189 to 1.0.190
- *(deps)* bump toml from 0.8.2 to 0.8.6
- Automerge dependabot
- *(deps)* bump tracing from 0.1.37 to 0.1.40
- Remove oidc
- *(deps)* bump openidconnect from 3.3.1 to 3.4.0
- *(deps)* bump serde from 1.0.188 to 1.0.189
- *(deps)* bump toml from 0.8.1 to 0.8.2
- *(deps)* bump rumqttc from 0.22.0 to 0.23.0
- *(deps)* bump tokio from 1.32.0 to 1.33.0
- *(deps)* bump rust from 1.72-bookworm to 1.73-bookworm
- *(deps)* bump clap from 4.4.4 to 4.4.6
- *(deps)* bump toml from 0.8.0 to 0.8.1
- *(deps)* bump clap from 4.4.3 to 4.4.4
- *(deps)* bump chrono from 0.4.30 to 0.4.31
- *(deps)* bump bytes from 1.4.0 to 1.5.0
- *(deps)* bump clap from 4.4.2 to 4.4.3
- *(deps)* bump toml from 0.7.8 to 0.8.0
- *(deps)* bump serde_json from 1.0.106 to 1.0.107
- *(deps)* bump toml from 0.7.6 to 0.7.8
- *(deps)* bump influxdb from 0.7.0 to 0.7.1
- *(deps)* bump openidconnect from 3.3.0 to 3.3.1
- *(deps)* bump serde_json from 1.0.105 to 1.0.106
- *(deps)* bump chrono from 0.4.28 to 0.4.30
- Map types as floats explicitly
- Always use a float type
- *(deps)* bump clap from 4.4.0 to 4.4.2
- *(deps)* bump url from 2.4.0 to 2.4.1
- *(deps)* bump chrono from 0.4.26 to 0.4.28
- Use same debian version
- *(deps)* bump serde from 1.0.183 to 1.0.188
- *(deps)* bump clap from 4.3.23 to 4.4.0
- rust 1.72
- Log levels via CLI
- Simplify
- Use tracing for logs
- Include temp_c
- Include tvoc
- Fix naming mismatch.
- *(deps)* bump clap from 4.3.22 to 4.3.23
- Push with default repo
- Start Rust port
- remove elixir config
- Use standard "message" key for messages
- Use JSON logging format
- more tracing
- Start tracing
- start emqtt
- Downgrade
- Start public_key
- Fix boot
- Tag release
- Merge pull request [#9](https://github.com/philipcristiano/hvac-iot-mqtt-influx/pull/9) from philipcristiano/rebar
- Start moving to rebar3
- Remove protocol from host
- Read a local config file
- Handle connection errors
- Handle connection errors
- Fix dialyze error
- erlftm
- Always read body
- Update hackney
- Add sentry
- Decode specific JSON messages
- Fix type for headers
- Don't use git version stuff as it breaks in the docker build action
- erlfmt
- Push to docker hub
- Post message to influxdb
- Use new GH branch default name
- Subscribe to metrics topic
- Init project
- Initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).