### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/philipcristiano/hvac-iot-mqtt-influx/compare/v0.1.4...v0.1.5) - 2024-01-21
+
+### Other
+- release
+
 ## [0.1.4](https://github.com/philipcristiano/hvac-iot-mqtt-influx/releases/tag/v0.1.4) - 2024-01-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hvac_iot"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hvac_iot"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Send MQTT HVAC-iot metrics to InfluxDB"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `hvac_iot`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/philipcristiano/hvac-iot-mqtt-influx/compare/v0.1.4...v0.1.5) - 2024-01-21

### Other
- release
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).