### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/philipcristiano/hvac-iot-mqtt-influx/compare/v0.1.6...v0.1.7) - 2024-01-29
+
+### Other
+- Update automerge
+- *(deps)* bump the patch-dependencies group with 1 update
+
 ## [0.1.6](https://github.com/philipcristiano/hvac-iot-mqtt-influx/compare/v0.1.5...v0.1.6) - 2024-01-22
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hvac_iot"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hvac_iot"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "Send MQTT HVAC-iot metrics to InfluxDB"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `hvac_iot`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.7](https://github.com/philipcristiano/hvac-iot-mqtt-influx/compare/v0.1.6...v0.1.7) - 2024-01-29

### Other
- Update automerge
- *(deps)* bump the patch-dependencies group with 1 update
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).